### PR TITLE
fix(deps): require google-api-core>=1.31.5, >=2.3.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ dependencies = [
     # NOTE: Maintainers, please do not require google-api-core>=2.x.x
     # Until this issue is closed
     # https://github.com/googleapis/google-cloud-python/issues/10566
-    "google-api-core[grpc] >= 1.28.0, <3.0.0dev",
+    "google-api-core[grpc] >= 1.31.5, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0",
     "proto-plus >= 1.15.0",
 ]
 

--- a/testing/constraints-3.6.txt
+++ b/testing/constraints-3.6.txt
@@ -4,5 +4,5 @@
 # Pin the version to the lower bound.
 # e.g., if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have google-cloud-foo==1.14.0
-google-api-core==1.28.0
+google-api-core==1.31.5
 proto-plus==1.15.0


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
fix(deps): require google-api-core>=1.31.5, >=2.3.2
END_COMMIT_OVERRIDE